### PR TITLE
Cache Path/Group data between pages

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -38,7 +38,7 @@
             })
             .then(function callModuleRenders(html) {
                 mainUI = $(html);
-                $('.breadcrumb').after(mainUI);
+                $('.main .content').prepend(mainUI);
                 uiLoaded = true;
 
                 setupContentClose();

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -69,13 +69,26 @@
         );
     }
 
+    function fetchOrBuildData(){
+      let cachedData = localStorage.getItem( 'tiyoAssistant' );
+      if (cachedData === null) {
+        return {
+            path: null,
+            group: null,
+            students: []
+        }
+      } else {
+        return JSON.parse(cachedData);
+      }
+    }
+
+    function setStoredData(data) {
+      localStorage.setItem( 'tiyoAssistant', JSON.stringify( data ) );
+    }
+
     function collectData() {
         let path = window.location.pathname.split(/\//),
-            data = {
-                path: null,
-                group: null,
-                students: []
-            },
+            data = fetchOrBuildData(),
             group = $('.card-block dt:contains("Group")').next().find('a');
 
         if (path.length === 4 && path[2] === 'paths') {
@@ -101,6 +114,7 @@
                         name: studentElem.text()
                     });
                 });
+                setStoredData(data);
                 return data;
             });
         } else {


### PR DESCRIPTION
A simple fix, that will cache group / path / student data in local storage.  This will allow for rendering of most content on pages other than paths once a user visits a path. (There are edge cases here revolving around user permissions)

@jakerella for your review :)