### PR TITLE
Instructor Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ While on a Path you can search all text in any lesson or assignment. Click on th
 
 Once the index is built, simply type you search query and hit enter. The results will appear immediately below the search box and will link to the pieces of content that query appears in.
 
+### Instructor Notes
+
+The instructor notes allow just that: notes by instructors (for instructors only). While viewing a path an instructor will now have an additional icon next to the "current" and "hide/show" icons to the right of each content piece (lesson or assignment). Clicking on the notes icon there (it looks like a sticky note) will pop up a simple modal for entering notes. These notes are saved in `localStorage` only!
+
+While viewing the content piece (lesson or assignment) as a student, the instructor will be able to view the notes at the top of the content, just above the description. Note that a student would never be able to see these since they would need the extension **and** the notes data from the instructor's `localStorage`.
+
+The instructor may also edit these notes on the individual content edit page by clicking on the notes icon in the top right next to all the other module icons.
+
+#### Sharing Notes
+
+Since the data for instructor notes is only stored in `localStorage` (for now) if an instructor wants to share notes with others - or just among two machines - they would have to export, and then import, the data. To do so, open the instructor notes module UI using the icon in the top right of TIYO, then click on the "Export JSON" button. This will save a JSON file to your computer which you can then share with others.
+
+To import instructor notes simply open the UI, select the JSON file on your machine (the one that was exported), and click on the "Import JSON" button. Note that the imported notes will be _merged_ with any you already have. That means that the extension will _never overwrite_ your existing notes. If you already have a note for a given content piece then the extension will add the imported notes under your own.
+
 ## To Hack On It
 
 First install the Grunt CLI if you don't have it already, then clone the repo, install dependencies, and build the project!

--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@
 
 This is a chrome extension to assist with The Iron Yard Online for instructors. Since this is not (yet?) a distributed extension, you will need to clone this repo (or download it) in order to use it.
 
-## To Use It
+* [Using this extension](#using-this-extension)
+  * [Install It](#install-it)
+  * [Gradebook](#gradebook)
+  * [Search](#search)
+  * [Instructor Notes](#instructor-notes)
+* [To Hack On It](#to-hack-on-it)
+* [Authors](#authors)
+
+## Using this extension
 
 ### Install It
 

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -102,13 +102,26 @@
                 id: Number(pathname[3]),
                 title: $('.content .breadcrumb li:eq(1)').text()
             };
+        } else if (pathname.length === 4 && pathname[1] === 'paths') {
+            data.path = {
+                id: Number(pathname[2]),
+                title: $('.m-pathheader-info-title').text()
+            };
         }
 
         if (pathname.length > 3 && (pathname[2] === 'lessons' || pathname[2] === 'assignments')) {
             data.content = {
                 id: Number(pathname[3]),
                 title: $('.content .breadcrumb li:eq(3)').text(),
-                type: pathname[2]
+                type: pathname[2],
+                isEdit: true
+            };
+        } else if (/paths\/[0-9]+\/units\/[0-9]+\/[^\/]+\/[0-9]+/.test(window.location.pathname)) {
+            data.content = {
+                id: Number(pathname[6]),
+                title: $('.m-lessonheader-title').text(),
+                type: pathname[5],
+                isEdit: false
             };
         }
 

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -97,31 +97,35 @@
 
         data.user = getUser();
 
-        if (pathname.length === 4 && pathname[2] === 'paths') {
+        // Admin view of path
+        if (/\/admin\/paths\/[0-9]+/.test(window.location.pathname)) {
             data.path = {
                 id: Number(pathname[3]),
                 title: $('.content .breadcrumb li:eq(1)').text()
             };
-        } else if (pathname.length === 4 && pathname[1] === 'paths') {
-            data.path = {
-                id: Number(pathname[2]),
-                title: $('.m-pathheader-info-title').text()
-            };
         }
 
-        if (pathname.length > 3 && (pathname[2] === 'lessons' || pathname[2] === 'assignments')) {
+        // Admin view of content piece
+        if (/\/admin\/(lessons|assignmnents)\/[0-9]+/.test(window.location.pathname)) {
             data.content = {
                 id: Number(pathname[3]),
                 title: $('.content .breadcrumb li:eq(3)').text(),
                 type: pathname[2],
-                isEdit: true
+                isAdmin: true
             };
-        } else if (/paths\/[0-9]+\/units\/[0-9]+\/[^\/]+\/[0-9]+/.test(window.location.pathname)) {
+        }
+
+        // Student view of content piece
+        if (/\/paths\/[0-9]+\/units\/[0-9]+\/[^\/]+\/[0-9]+/.test(window.location.pathname)) {
+            data.path = {
+                id: Number(pathname[2]),
+                title: $('.m-pathheader-info-title').text()
+            };
             data.content = {
                 id: Number(pathname[6]),
                 title: $('.m-lessonheader-title').text(),
                 type: pathname[5],
-                isEdit: false
+                isAdmin: false
             };
         }
 

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -104,10 +104,10 @@
             };
         }
 
-        if (pathname.length === 4 && (pathname[2] === 'lessons' || pathname[2] === 'assignments')) {
+        if (pathname.length > 3 && (pathname[2] === 'lessons' || pathname[2] === 'assignments')) {
             data.content = {
                 id: Number(pathname[3]),
-                title: $('.content .breadcrumb li:last-child').text(),
+                title: $('.content .breadcrumb li:eq(3)').text(),
                 type: pathname[2]
             };
         }

--- a/src/scripts/modules/notes.js
+++ b/src/scripts/modules/notes.js
@@ -161,20 +161,11 @@
 
     function addViewContentNotesUI() {
         let notes = notesData[pageData.content.id] || '';
-        $.get(chrome.extension.getURL(NOTES_TEMPLATE)).then(function(html) {
-            let $form = $('.l-content .py2')
-                .after(
-                    $(`<section class='tiyo-assistant-notes-container'></section>`)
-                        .append(html)
-                )
-                .next('.tiyo-assistant-notes-container')
-                    .find('form');
 
-            setupForm($form, pageData.content, notes)
-                .submit(saveNotes)
-                .find('.tiyo-assistant-note-cancel')
-                    .remove();
-        });
+        $(`<section class='tiyo-assistant-notes-container'></section>`)
+            .append('<h4>Instructor Notes</h4>')
+            .append(notes.replace(/\n/g, '<br>'))
+            .appendTo('.l-content .py2');
     }
 
     function saveNotes(e) {

--- a/src/scripts/modules/notes.js
+++ b/src/scripts/modules/notes.js
@@ -58,6 +58,18 @@
         });
     }
 
+    function setupForm(form, content, notes) {
+        return form
+            .attr('data-id', content.id)
+            .find('.tiyo-assistant-note-title')
+                .text(content.title)
+                .end()
+            .find('textarea')
+                .val(notes)
+                .end()
+            .show();
+    }
+
     function showNotesModal(contentNode, modalNode) {
         let id = contentNode.data('id').match(/^gid:\/\/online\/[^\/]+\/([0-9]+)$/);
         if (!id) {
@@ -66,67 +78,46 @@
         }
         id = id[1];
 
-        console.log('showing modal for', id, modalNode);
-
         let notes = notesData[id] || '';
 
-        modalNode
-            .attr('data-id', id)
-            .find('.tiyo-assistant-note-title')
-                .text(contentNode.find('.text-body').text())
-                .end()
-            .find('textarea')
-                .val(notes)
-                .end()
+        setupForm(modalNode, {
+            id: id,
+            title: contentNode.find('.text-body').text()
+        }, notes)
             .css({
                 top: (contentNode.height() * 2) + contentNode.offset().top,
                 left: contentNode.offset().left
-            })
-            .show();
+            });
     }
 
     function addEditContentNotesUI() {
         let notes = notesData[pageData.content.id] || '';
+
         $.get(chrome.extension.getURL(NOTES_TEMPLATE)).then(function(html) {
-            $ui.append(html)
-                .find('form')
-                    .attr('data-id', pageData.content.id)
-                    .find('.tiyo-assistant-note-title')
-                        .text(pageData.content.title)
-                        .end()
-                    .find('textarea')
-                        .val(notes)
-                        .end()
-                    .find('.tiyo-assistant-note-cancel')
-                        .remove()
-                        .end()
-                    .show()
-                    .submit(saveNotes);
+            let $form = $ui.append(html).find('form');
+
+            setupForm($form, pageData.content, notes)
+                .submit(saveNotes)
+                .find('.tiyo-assistant-note-cancel')
+                    .remove();
         });
     }
 
     function addViewContentNotesUI() {
         let notes = notesData[pageData.content.id] || '';
         $.get(chrome.extension.getURL(NOTES_TEMPLATE)).then(function(html) {
-            $('.l-content .py2')
+            let $form = $('.l-content .py2')
                 .after(
                     $(`<section class='tiyo-assistant-notes-container'></section>`)
                         .append(html)
                 )
                 .next('.tiyo-assistant-notes-container')
-                    .find('form')
-                    .attr('data-id', pageData.content.id)
-                    .find('.tiyo-assistant-note-title')
-                        .text(pageData.content.title)
-                        .end()
-                    .find('textarea')
-                        .val(notes)
-                        .end()
-                    .find('.tiyo-assistant-note-cancel')
-                        .remove()
-                        .end()
-                    .show()
-                    .submit(saveNotes);
+                    .find('form');
+
+            setupForm($form, pageData.content, notes)
+                .submit(saveNotes)
+                .find('.tiyo-assistant-note-cancel')
+                    .remove();
         });
     }
 

--- a/src/scripts/modules/notes.js
+++ b/src/scripts/modules/notes.js
@@ -28,8 +28,10 @@
 
         if (pageData.path && pageData.path.id) {
             addNotesIcons();
+        } else if (pageData.content && pageData.content.id && pageData.content.isEdit) {
+            addEditContentNotesUI();
         } else if (pageData.content && pageData.content.id) {
-            addContentNotesUI();
+            addViewContentNotesUI();
         }
     }
 
@@ -83,11 +85,36 @@
             .show();
     }
 
-    function addContentNotesUI() {
+    function addEditContentNotesUI() {
         let notes = notesData[pageData.content.id] || '';
         $.get(chrome.extension.getURL(NOTES_TEMPLATE)).then(function(html) {
             $ui.append(html)
                 .find('form')
+                    .attr('data-id', pageData.content.id)
+                    .find('.tiyo-assistant-note-title')
+                        .text(pageData.content.title)
+                        .end()
+                    .find('textarea')
+                        .val(notes)
+                        .end()
+                    .find('.tiyo-assistant-note-cancel')
+                        .remove()
+                        .end()
+                    .show()
+                    .submit(saveNotes);
+        });
+    }
+
+    function addViewContentNotesUI() {
+        let notes = notesData[pageData.content.id] || '';
+        $.get(chrome.extension.getURL(NOTES_TEMPLATE)).then(function(html) {
+            $('.l-content .py2')
+                .after(
+                    $(`<section class='tiyo-assistant-notes-container'></section>`)
+                        .append(html)
+                )
+                .next('.tiyo-assistant-notes-container')
+                    .find('form')
                     .attr('data-id', pageData.content.id)
                     .find('.tiyo-assistant-note-title')
                         .text(pageData.content.title)

--- a/src/scripts/modules/notes.js
+++ b/src/scripts/modules/notes.js
@@ -29,7 +29,7 @@
 
         if (pageData.path && pageData.path.id) {
             addNotesIcons();
-        } else if (pageData.content && pageData.content.id && pageData.content.isEdit) {
+        } else if (pageData.content && pageData.content.id && pageData.content.isAdmin) {
             addEditContentNotesUI();
         } else if (pageData.content && pageData.content.id) {
             addViewContentNotesUI();

--- a/src/scripts/modules/notes.js
+++ b/src/scripts/modules/notes.js
@@ -1,0 +1,53 @@
+(function(tiy) {
+    'use strict';
+
+    const NOTES_KEY = 'tiyo-notes';
+    const TEMPLATE = 'build/templates/notes.html';
+
+    let $ui = null;
+    let pageData = {};
+    let pathData = {};
+
+    tiy.loadModule({
+        name: 'notes',
+        navIcon: 'fa-sticky-note-o',
+        render: main
+    });
+
+    function main(data, elem) {
+        let notesData = {};
+
+        $ui = $(elem);
+        pageData = data;
+
+        if (!pageData.path || !pageData.path.id) {
+            return;
+        }
+
+        try { notesData = JSON.parse(localStorage.getItem(NOTES_KEY) || '{}'); } catch(e) { /* let this go */ }
+        console.info('loading notes module with notesData:', notesData);
+
+        if (notesData[pageData.path.id]) {
+            pathData = notesData[pageData.path.id];
+        }
+
+        addNoteIcons();
+    }
+
+    function addNoteIcons() {
+        $.get(chrome.extension.getURL(TEMPLATE)).then(function(html) {
+            let notesModal = $(html);
+            $ui.append(notesModal);
+            $('.path-tree-states').after($(`<i class='fa fa-sticky-note-o tiyo-assistant-note'></i>`));
+            $('.path-tree').on('click', '.tiyo-assistant-note', function() {
+                showNoteModal($(this).parents('.lesson, .assignment'), notesModal);
+            });
+        });
+    }
+
+    function showNoteModal(content, modal) {
+        console.log('showing modal for', content, modal);
+    }
+
+
+})(window.tiy || {});

--- a/src/scripts/modules/notes.js
+++ b/src/scripts/modules/notes.js
@@ -34,6 +34,8 @@
     }
 
     function addNotesIcons() {
+        $ui.append(`<p>Please use the note icons next to each content line in your units!</p>`);
+
         $.get(chrome.extension.getURL(NOTES_TEMPLATE)).then(function(html) {
             let notesModal = $(html);
             notesModal.addClass('tiyo-assistant-modal');

--- a/src/styles/_notes.scss
+++ b/src/styles/_notes.scss
@@ -10,6 +10,11 @@ i.tiyo-assistant-note:hover {
     color: #999;
 }
 
+.tiyo-assistant-notes-container {
+    max-width: 48rem;
+    margin: 0 auto;
+}
+
 form.tiyo-assistant-note {
     background-color: #fff;
     padding: 1em;

--- a/src/styles/_notes.scss
+++ b/src/styles/_notes.scss
@@ -11,13 +11,22 @@ i.tiyo-assistant-note:hover {
 }
 
 form.tiyo-assistant-note {
-    display: none;
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 40%;
     background-color: #fff;
     padding: 1em;
+
+    &::after {
+        content: "";
+        display: table;
+        clear: both;
+    }
+
+    &.tiyo-assistant-modal {
+        display: none;
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 40%;
+    }
 
     textarea {
         width: 100%;
@@ -27,10 +36,4 @@ form.tiyo-assistant-note {
 
 .tiyo-assistant-note-save {
     float: right;
-
-    &::after {
-        content: "";
-        display: table;
-        clear: both;
-    }
 }

--- a/src/styles/_notes.scss
+++ b/src/styles/_notes.scss
@@ -13,6 +13,13 @@ i.tiyo-assistant-note:hover {
 .tiyo-assistant-notes-container {
     max-width: 48rem;
     margin: 0 auto;
+    margin-top: 1em;
+    border-top: 1px solid #999;
+    border-bottom: 1px solid #999;
+
+    h4 {
+        text-align: right;
+    }
 }
 
 form.tiyo-assistant-note {

--- a/src/styles/_notes.scss
+++ b/src/styles/_notes.scss
@@ -1,11 +1,36 @@
 
-.tiyo-assistant-note {
+i.tiyo-assistant-note {
     display: inline-block;
     float: right;
     padding-top: 3px;
     margin-right: 0.8em;
     cursor: pointer;
 }
-.tiyo-assistant-note:hover {
+i.tiyo-assistant-note:hover {
     color: #999;
+}
+
+form.tiyo-assistant-note {
+    display: none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 40%;
+    background-color: #fff;
+    padding: 1em;
+
+    textarea {
+        width: 100%;
+        height: 6em;
+    }
+}
+
+.tiyo-assistant-note-save {
+    float: right;
+
+    &::after {
+        content: "";
+        display: table;
+        clear: both;
+    }
 }

--- a/src/styles/_notes.scss
+++ b/src/styles/_notes.scss
@@ -42,3 +42,8 @@ form.tiyo-assistant-note {
 .tiyo-assistant-note-save {
     float: right;
 }
+
+.tiyo-assistant-notes-import {
+    float: right;
+    width: 50%;
+}

--- a/src/styles/_notes.scss
+++ b/src/styles/_notes.scss
@@ -1,0 +1,11 @@
+
+.tiyo-assistant-note {
+    display: inline-block;
+    float: right;
+    padding-top: 3px;
+    margin-right: 0.8em;
+    cursor: pointer;
+}
+.tiyo-assistant-note:hover {
+    color: #999;
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -2,3 +2,4 @@
 @import "content";
 @import "gradebook";
 @import "search";
+@import "notes";

--- a/src/templates/notes.html
+++ b/src/templates/notes.html
@@ -1,0 +1,3 @@
+<section>
+    <p class='tiyo-assistant-note-box' contenteditable>Here be the notes.</p>
+</section>

--- a/src/templates/notes.html
+++ b/src/templates/notes.html
@@ -1,3 +1,6 @@
-<section>
-    <p class='tiyo-assistant-note-box' contenteditable>Here be the notes.</p>
-</section>
+<form class='tiyo-assistant-note card'>
+    <p>Notes for <span class='tiyo-assistant-note-title'></span></p>
+    <textarea>Here be the notes.</textarea>
+    <input type='submit' value='Save' class='tiyo-assistant-note-save btn btn-primary'>
+    <input type='button' value='Cancel' class='tiyo-assistant-note-cancel btn btn-secondary'>
+</form>

--- a/src/templates/notes_path.html
+++ b/src/templates/notes_path.html
@@ -1,0 +1,11 @@
+
+<p class='tiyo-assistant-notice'></p>
+
+<aside class='tiyo-assistant-notes-actions'>
+    <form class='tiyo-assistant-notes-import'>
+        <input type='submit' class='btn btn-primary-outline' value='Import JSON'>
+        <input type='file' required>
+    </form>
+
+    <a href='#' class='tiyo-assistant-notes-export btn btn-info' download='tiyo-notes.json'>Export JSON</a>
+</aside>


### PR DESCRIPTION
This PR implements arbitrary instructor notes on a per-content page basis. The notes can be accessed via icons on the path admin page or on the individual content piece edit pages. They are viewable on the content view pages as well.

Note that these are only stored in localStorage and thus not shareable among instructors directly. However, there is an import/export feature for doing so (a stopgap solution for now).