### PR TITLE
Unified notifications

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -3,11 +3,13 @@
 
     // Public API methods
     tiy.loadModule = loadModule;
+    tiy.showMessage = showMessage;
 
     // locals & constants
     let tiyoData = null;
     let navUI = null;
     let mainUI = null;
+    let notifyUI = null;
     let modulesLoaded = [];
     let moduleDisplayed = null;
     let dataLoaded = false;
@@ -15,12 +17,14 @@
 
     const MAIN_TEMPLATE = 'templates/main.html';
     const NAV_TEMPLATE = 'templates/nav.html';
+    const NOTIFICATIONS_TEMPLATE = 'templates/notifications.html';
     const PANEL_ANIMATION_TIME = 200;
 
     function main() {
         console.info('Initializing TIYO assistant');
 
         addFontAwesomeStyleSheet();
+        setupNotificationsUI();
 
         collectData()
         .then(function getNavUI(data) {
@@ -214,6 +218,36 @@
         var elem = $(`<article data-module='${mod.name}'>`).addClass('tiyo-assistant-module');
         $(mainUI).find('.tiyo-assistant-content').append(elem);
         return elem;
+    }
+
+    function setupNotificationsUI() {
+        $.get(chrome.extension.getURL(NOTIFICATIONS_TEMPLATE)).then(function(html) {
+            notifyUI = $(html).appendTo('body');
+            notifyUI.on('click', '.close', function() {
+                $(this).parent().fadeOut(function() { $(this).remove(); });
+            });
+        });
+    }
+
+    function showMessage(msg, options = {}) {
+        options.type = options.type || 'danger';
+        options.duration = (Number(options.duration) || options.duration === 0) ? options.duration : 4;
+
+        let dismissable = (options.canDismiss === false) ? '' : 'alert-dismissible';
+
+        let msgNode = $(`<p class='alert alert-${options.type} ${dismissable}'>`).text(msg);
+
+        if (dismissable.length) {
+            msgNode.append(`<button class='close'>&times;</button>`);
+        }
+
+        notifyUI.append(msgNode);
+
+        if (options.duration && options.duration > 0) {
+            setTimeout(function() {
+                msgNode.fadeOut(function() { $(this).remove(); });
+            }, (options.duration * 1000));
+        }
     }
 
     // Kick things off...

--- a/src/scripts/modules/notes.js
+++ b/src/scripts/modules/notes.js
@@ -54,7 +54,6 @@
 
     function importNotes(e) {
         e.preventDefault();
-        $('.tiyo-assistant-notice').text('');
 
         let $fileInput = $(this).find('[type=file]');
         let reader = new FileReader();
@@ -64,14 +63,14 @@
             try {
                 data = JSON.parse(readEvent.target.result);
             } catch(err) {
-                $('.tiyo-assistant-notice').text('It looks like that is not a valid JSON file!');
+                tiy.showMessage('It looks like that is not a valid JSON file!', { duration: 0 });
             }
             console.info('importing data', data);
             $fileInput.val('');
 
             if (data) {
                 mergeNotesData(data);
-                $('.tiyo-assistant-notice').text('Notes data imported and merged!');
+                tiy.showMessage('Notes data imported and merged!', { type: 'success' });
             }
         };
         reader.readAsText($fileInput[0].files[0]);
@@ -186,6 +185,7 @@
         notesData[''+id] = notes;
         localStorage.setItem(NOTES_KEY, JSON.stringify(notesData));
         updateNotesExport();
+        tiy.showMessage('Notes Saved!', { type: 'success', duration: 2 });
     }
 
 

--- a/src/scripts/modules/search.js
+++ b/src/scripts/modules/search.js
@@ -56,13 +56,13 @@
     }
 
     function doSearch(query, indexData) {
-        $ui.find('.tiyo-assistant-notice').text('');
         $('.tiyo-assistant-search-results li').remove();
 
         if (!query) { return; }
 
         if (!indexData || !indexData[pageData.path.id]) {
-            return $ui.find('.tiyo-assistant-notice').text('There is no indexfor this path, please build it!');
+            tiy.showMessage('There is no index for this path, please build it!', { type: 'info' });
+            return;
         }
 
         console.info('searching path %d for %s', pageData.path.id, query);
@@ -100,7 +100,7 @@
         let resultIDs = Object.keys(results);
 
         if (!resultIDs.length) {
-            $ui.find('.tiyo-assistant-notice').text('Looks like there were no results!');
+            tiy.showMessage('Looks like there were no results!', { type: 'info' });
             return;
         }
 
@@ -124,7 +124,7 @@
 
     function buildIndex(indexData) {
         $ui.find('.tiyo-assistant-search-refresh').attr('disabled', 'disabled');
-        $ui.find('.tiyo-assistant-notice').text('Recreating... this could take a while.');
+        tiy.showMessage('Creating new index... this could take a while.', { type: 'info' });
 
         let pathIndex = Object.create(null);
         pathIndex.__createTime = Date.now();
@@ -164,12 +164,12 @@
                 addIndexAge(indexData);
 
                 $ui.find('.tiyo-assistant-search-refresh').attr('disabled', '');
-                $ui.find('.tiyo-assistant-notice').text('');
+                tiy.showMessage('New index built!', { type: 'success' });
             })
             .catch(function(err) {
                 console.warn('Problem getting content index', err);
                 $ui.find('.tiyo-assistant-search-refresh').attr('disabled', false);
-                $ui.find('.tiyo-assistant-notice').text('There was a problem building the index, feel free to try again!');
+                tiy.showMessage('There was a problem building the index, please try again (TIYO throws 500 errors sometimes)!');
             });
     }
 

--- a/src/styles/_notifications.scss
+++ b/src/styles/_notifications.scss
@@ -1,0 +1,7 @@
+
+.tiyo-assistant-notifications {
+    position: fixed;
+    top: 0.5em;
+    left: 20%;
+    width: 60%;
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -3,3 +3,4 @@
 @import "gradebook";
 @import "search";
 @import "notes";
+@import "notifications";

--- a/src/templates/notes_path.html
+++ b/src/templates/notes_path.html
@@ -1,6 +1,4 @@
 
-<p class='tiyo-assistant-notice'></p>
-
 <aside class='tiyo-assistant-notes-actions'>
     <form class='tiyo-assistant-notes-import'>
         <input type='submit' class='btn btn-primary-outline' value='Import JSON'>

--- a/src/templates/notifications.html
+++ b/src/templates/notifications.html
@@ -1,0 +1,1 @@
+<aside class='tiyo-assistant-notifications'></aside>

--- a/src/templates/search.html
+++ b/src/templates/search.html
@@ -1,6 +1,4 @@
 
-<p class='tiyo-assistant-notice'></p>
-
 <nav class='tiyo-assistant-search'>
     <button class='btn btn-secondary btn-sm tiyo-assistant-search-refresh'>Refresh Index</button>
     <p class='tiyo-assistant-search-age'>(Index created <time></time>)</p>


### PR DESCRIPTION
This PR implements a new method on the `tiy` namespace to allow a more unified way to show messages to the user (see issue #17). I have implemented the method and used it in the Notes and Search modules.

The basic usage is simple:

`window.tiy.showMessage('the message text', { type: 'success', duration: 5, canDismiss: false });`

The code above would show the given message in a green background (using bootstrap alerts) for five seconds and _not_ allow the user to close it manually.

The default options are a red background ("danger"), 4 second duration, and the ability to close manually with an "X" on the right of the message. Messages are positioned statically at the top of the page for better visibility.