### PR TITLE
Show two characters for assignment names

### DIFF
--- a/src/scripts/modules/gradebook.js
+++ b/src/scripts/modules/gradebook.js
@@ -186,7 +186,7 @@
             row.append( `
               <th data-tooltip='${assignment.name}'>
                 <a href='${assignment.href}' title='${assignment.name}'>
-                  ${assignment.name.slice( 0, 2 )}
+                  ${assignment.title.slice( 0, 2 )}
                 </a>
               </th>
             ` );

--- a/src/scripts/modules/gradebook.js
+++ b/src/scripts/modules/gradebook.js
@@ -183,7 +183,7 @@
             row.append( `
               <th data-tooltip='${assignment.name}'>
                 <a href='${assignment.href}' title='${assignment.name}'>
-                  ${assignment.name.slice( 0, 1 )}
+                  ${assignment.name.slice( 0, 2 )}
                 </a>
               </th>
             ` );


### PR DESCRIPTION
A few instructors are using numbers as the first part of assignment names so then the header is hard to read 
![screen shot 2016-06-18 at 3 20 25 pm](https://cloud.githubusercontent.com/assets/2532004/16173488/41f8fc34-3568-11e6-9692-c89b28b48ecd.png)
