### PR TITLE
Allow tagging of content (and search by them)

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -105,7 +105,8 @@
         if (/\/admin\/paths\/[0-9]+/.test(window.location.pathname)) {
             data.path = {
                 id: Number(pathname[3]),
-                title: $('.content .breadcrumb li:eq(1)').text()
+                title: $('.content .breadcrumb li:eq(1)').text(),
+                onPage: true
             };
         }
 
@@ -123,7 +124,8 @@
         if (/\/paths\/[0-9]+\/units\/[0-9]+\/[^\/]+\/[0-9]+/.test(window.location.pathname)) {
             data.path = {
                 id: Number(pathname[2]),
-                title: $('.m-pathheader-info-title').text()
+                title: $('.m-pathheader-info-title').text(),
+                onPage: false
             };
             data.content = {
                 id: Number(pathname[6]),

--- a/src/scripts/modules/search.js
+++ b/src/scripts/modules/search.js
@@ -91,7 +91,7 @@
             $(this).after(tagItems);
         });
 
-        $('.path-tree-states').after($(`<i class='fa fa-tag tiyo-assistant-add-tag'></i>`));
+        $('.path-tree-states').after($(`<i class='fa fa-tag tiyo-assistant-add-tag' title='Add a tag to this content'></i>`));
 
         $('.path-tree')
             .on('click', '.tiyo-assistant-tag', function() {

--- a/src/scripts/modules/search.js
+++ b/src/scripts/modules/search.js
@@ -6,7 +6,7 @@
     const TEMPLATE = 'templates/search.html';
     const SCRAPE_BASE = 'https://online.theironyard.com';
     const FILLERS = /\b(an|and|are(n\'t)?|as|at|be|but|by|do(es)?(n\'t)?|for|from|if|in|into|is(n\'t)?|it\'?s?|no|none|not|of|on|or|such|that|the|theirs?|then|there(\'s)?|these|they|this|to|us|was|we|will|with|won\'t|you\'?r?e?)\b/g;
-    const TAG_WEIGHT = 5;
+    const TAG_WEIGHT = 10;
 
     let $ui = null;
     let tagData = {};
@@ -37,6 +37,13 @@
                     $ui.find('form').submit(function(e) {
                         e.preventDefault();
                         doSearch($(this).find('[type=text]').val(), indexData);
+                    });
+                    $('.tiyo-assistant-search-results').on('click', '.tiyo-assistant-tag', function() {
+                        $ui.find('form')
+                            .find('input[type=text]')
+                                .val($(this).text())
+                                .end()
+                            .submit();
                     });
                 });
 
@@ -119,7 +126,6 @@
             u: unit,
             id: Number(href[2]),
             p: pageData.path.id,
-            w: TAG_WEIGHT,
             t: (href[1] === 'lessons') ? 'l' : 'a'
         };
     }
@@ -206,7 +212,11 @@
             .map(function(token) {
                 // map to the matched content
                 let matches = index[token] || [];
-                matches = matches.concat(tagData[token] || []);
+                let tagMatches = (tagData[token] || []).map(function(match) {
+                    match.w = TAG_WEIGHT;
+                    return match;
+                });
+                matches = matches.concat(tagMatches);
                 return matches;
             })
             .forEach(function(matches) {

--- a/src/styles/_search.scss
+++ b/src/styles/_search.scss
@@ -18,11 +18,12 @@ form.tiyo-assistant-search [type=text] {
     background-image: none;
     border: 0.0625rem solid #ccc;
     border-radius: 0.25rem;
-}
-form.tiyo-assistant-search [type=text]:focus {
-    outline: none;
-    box-shadow: 0 0 5px rgba(81, 203, 238, 1);
-    border: 1px solid transparent;
+
+    &:focus {
+        outline: none;
+        box-shadow: 0 0 5px rgba(81, 203, 238, 1);
+        border: 1px solid transparent;
+    }
 }
 
 .tiyo-assistant-search-age {
@@ -31,4 +32,43 @@ form.tiyo-assistant-search [type=text]:focus {
     font-size: 0.9em;
     color: #666;
     padding-top: 0.3em;
+}
+
+.tiyo-assistant-tag {
+    margin-left: 0.5em;
+    cursor: pointer;
+
+    &:hover {
+        background-color: #508d9f;
+        text-decoration: line-through;
+    }
+}
+
+i.tiyo-assistant-add-tag {
+    display: inline-block;
+    float: right;
+    padding-top: 3px;
+    margin-right: 0.8em;
+    cursor: pointer;
+    color: #666;
+
+    &:hover {
+        color: #333;
+    }
+}
+
+input.tiyo-assistant-new-tag {
+    display: none;
+    margin-left: 0.5em;
+    color: #656D78;
+    background-color: #fff;
+    background-image: none;
+    border: 0.0625rem solid #ccc;
+    border-radius: 0.25rem;
+
+    &:focus {
+        outline: none;
+        box-shadow: 0 0 5px rgba(81, 203, 238, 1);
+        border: 1px solid transparent;
+    }
 }

--- a/src/styles/_search.scss
+++ b/src/styles/_search.scss
@@ -40,8 +40,10 @@ form.tiyo-assistant-search [type=text] {
 
     &:hover {
         background-color: #508d9f;
-        text-decoration: line-through;
     }
+}
+.path-tree .tiyo-assistant-tag:hover {
+    text-decoration: line-through;
 }
 
 i.tiyo-assistant-add-tag {


### PR DESCRIPTION
This PR implements #22... it allows an instructor to add tags to content on a path. These tags are visible next to the content title and when searching, tags are given increased weight. Clicking on a tag in the search results allows a user to quickly see results for that tag (altering the search query).

This is a first pass, so any input is thoroughly welcome. I have other ideas for additional features in this area, but I wanted to get a basic implementation in place first.

@rposborne: ready for review.