### PR TITLE
Add ability to filter gradebook data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules/
 build/
 *.crx
 *.zip
+.idea/
+tiyo-assistant.iml

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -61,7 +61,7 @@
 
     /**
     * Chrome extensions have issues with access files from css like fonts, so
-    * we need to embed the styelsheet using the chromse extension URL, which
+    * we need to embed the stylesheet using the chrome's extension URL, which
     * is dynamically generated. The remainder of the FA styles are in a static
     * stylesheet in /vendor
     */
@@ -100,7 +100,8 @@
                 path: null,
                 content: null,
                 group: null,
-                students: []
+                students: [],
+                settings: {}
             },
             group = $('.card-block dt:contains("Group")').next().find('a');
 

--- a/src/styles/_gradebook.scss
+++ b/src/styles/_gradebook.scss
@@ -1,12 +1,24 @@
 .tiyo-assistant {
+    #display-options{
+        float: right;
+    }
+    div.grades{
+        overflow-x: scroll !important;
+    }
+    label{
+        margin: auto 0.5em;
+    }
     table.table {
         td,
         th {
+            border-right: 1px solid #F5F5F5;
             font-size: 0.6em;
             padding: 0;
             position: relative;
+            text-align: center;
             &:nth-child(-n+2) {
                 font-size: 0.8em;
+                text-align: left;
             }
             &.u {
                 background-color: #e74c3c;
@@ -23,7 +35,10 @@
             &.s {
                 background-color: #6fbbb7;
             }
-            &.grade a {
+            &.none {
+                min-width: 1em;
+            }
+            &.grade a, &.grade span {
                 display: block;
                 width: 100%;
                 padding: 0.4rem !important;
@@ -45,6 +60,20 @@
                 z-index: 3;
                 border-radius: 2px;
             }
+        }
+        td:first-child{
+            white-space: nowrap;
+        }
+        a.title{
+            display: block;
+            font-size: 0;
+            overflow: hidden;
+            white-space: nowrap;
+        }
+        a.title:first-letter{
+            display: block;
+            visibility: visible;
+            font-size: 0.6rem;
         }
     }
 }


### PR DESCRIPTION
I changed how gradebook data was collected. It now includes an assignment's due date. According to Tiyo, an assignment is only required if it has a due date and it's not hidden.

I changed how the gradebook is rendered. Assignments are now listed left to right, with the oldest shown to the left. (This could be reversed, obviously.) I added checkboxes that allow instructors to select what assignments to display. Combinations of selections can be made. For example, if I check all four checkboxes all assignments show, even those that I have no intention of giving to students.

As assignments are shown or hidden student grades are updated. This allows me to uncheck all boxes to see only the assignments that are open and have submissions and are required. I can easily tell what students are doing well and which are not, without extraneous information. Additionally, I can see how far a given student is in the entire class.

I changed the display styles a bit too. For example, there is now a vertical line separating grades. The column header is centered directly above the column it relates to.

Lastly, I updated the display so that if I select the entire table and copy and paste it into a spreadsheet that I can see the full name of the assignment, not just the first letter.

One last note, the indenting in the gradebook.js was inconsistent. In some places it used two spaces, in others it used tabs. I tried to follow the conventions used in any particular section, as much as possible, without reformatting the entire file.